### PR TITLE
Bring back Vain Shrouds in v60 & Cull Vain Shroud feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 ## v1.3.0
 * Added a feature to bring back the Vain Shrouds in v60 (Requested by [MiraakThuri](https://github.com/EssieFir/SoberShip/issues/2))
 * Added a feature to prevent the Vain Shrouds being reset when they fail to spawn.
-* Added an unfinished feature to cull Vain Shrouds if there are too many.
-* Updated config descriptions to describe what they do in v60 specifically.
-
-## v1.2.2
-* Added the option to set the maximum amount of Vain Shrouds that can exist (defaults to false)
+* Added a feature to cap Vain Shroud iterations if it's too high.
+* Updated config descriptions to describe what they do in v60.
 
 ## v1.2.1
 * Fixed an issue where the level would never start if a non-host had the mod installed and vain shrouds tried to spawn.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.3.0
+* Added a feature to bring back the Vain Shrouds in v60 (Requested by [MiraakThuri](https://github.com/EssieFir/SoberShip/issues/2))
+* Added a feature to prevent the Vain Shrouds being reset when they fail to spawn.
+* Added an unfinished feature to cull Vain Shrouds if there are too many.
+* Updated config descriptions to describe what they do in v60 specifically.
+
 ## v1.2.2
 * Added the option to set the maximum amount of Vain Shrouds that can exist (defaults to false)
 
@@ -20,3 +26,6 @@
 
 ## v1.1.0
 * Now removes newly generated Vain Shrouds as well.
+
+## v1.0.0
+* Created the mod

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # SoberShip
-Make the Vain Shrouds go bye bye when near ship.<br>
+~~Fixes a bug in the game that causes Vain Shrouds to spawn on the ship.~~<br>
+Brings back the Vain Shrouds (and the fox) in v60! <br>
+Also fixes old saves that still have Vain Shrouds on the ship.
 
 ## Features
-* Relocates the Vain Shroud spawn position to somewhere away from the ship, if it's too close. (enabled by default, added in v1.2)
+* Tested to work with v61.
+* Server-Side (Only the host needs the mod installed for it to work!)
+* Un-Disables the Vain Shrouds (enabled by default).
+* Relocates the Vain Shroud spawn position to somewhere away from the ship, if it's too close. (enabled by default)
 * Removes existing/spreading Vain Shrouds that are too close to the ship (enabled by default)
-* The option to disable Vain Shrouds completely, which also disables the fox (disabled by default, added in v1.2)
-* The option to cap the amount of Vain Shrouds that can exist (disabled by default, potentially upcoming in v1.2.2)
+* The option to disable Vain Shrouds completely, which also disables the fox (disabled by default)
+* (broken, but kind of works) The option to cap the amount of Vain Shrouds that can exist (disabled by default)
 
-*All features are configurable and can be tweaked or disabled.<br>
-(Make sure to restart your game after making config changes)
+All features are configurable and can be tweaked or disabled.<br>
+This mod works with [Lethal Config](https://thunderstore.io/c/lethal-company/p/AinaVT/LethalConfig/) and does not require a restart to set any config options.<br>
+Proper support for Lethal Config is planned.
 
-[Changelog](https://thunderstore.io/c/lethal-company/p/essie/SoberShip/changelog/)
+If you find a bug or have a suggestion feel free to open an issue on this mods [GitHub page](https://github.com/EssieFir/SoberShip/issues).
+
+---
+[SoberShip Changelog](https://thunderstore.io/c/lethal-company/p/essie/SoberShip/changelog/)
+
+*Make the Vain Shrouds go bye bye when near ship.*

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Also fixes old saves that still have Vain Shrouds on the ship.
 * Un-Disables the Vain Shrouds (enabled by default).
 * Relocates the Vain Shroud spawn position to somewhere away from the ship, if it's too close. (enabled by default)
 * Removes existing/spreading Vain Shrouds that are too close to the ship (enabled by default)
+* Cap Vain Shroud iterations (enabled by default)
 * The option to disable Vain Shrouds completely, which also disables the fox (disabled by default)
-* (broken, but kind of works) The option to cap the amount of Vain Shrouds that can exist (disabled by default)
 
 All features are configurable and can be tweaked or disabled.<br>
-This mod works with [Lethal Config](https://thunderstore.io/c/lethal-company/p/AinaVT/LethalConfig/) and does not require a restart to set any config options.<br>
+This mod works with [Lethal Config](https://thunderstore.io/c/lethal-company/p/AinaVT/LethalConfig/) and does not require a restart to apply any config changes.<br>
 Proper support for Lethal Config is planned.
 
 If you find a bug or have a suggestion feel free to open an issue on this mods [GitHub page](https://github.com/EssieFir/SoberShip/issues).

--- a/SoberShip/Config/ConfigOptions.cs
+++ b/SoberShip/Config/ConfigOptions.cs
@@ -33,24 +33,24 @@ namespace SoberShip.Config
         public static void Init(ConfigFile config)
         {
             string category = "v60 Settings";
-            BringBackVainShrouds = config.Bind<bool>(category, "BringBackVainShrouds", true, "Bring back Vain Shrouds (including the fox) again in v60. Disable this if you're having issues with other mods.");
-            FixFalseVainShroudRemoval = config.Bind<bool>(category, "FixFalseVainShroudRemoval", false, "In v60, if the Vain Shrouds fail to spawn they are reset completely, this setting makes sure they aren't reset if they fail to spawn.");
+            BringBackVainShrouds = config.Bind<bool>(category, "BringBackVainShrouds", true, "Bring back Vain Shrouds (including the fox) again in v60.\nDisable this if you're having issues with other mods.");
+            FixFalseVainShroudRemoval = config.Bind<bool>(category, "FixFalseVainShroudRemoval", false, "In v60, if the Vain Shrouds fail to spawn they are reset completely,\nthis setting makes sure they aren't reset if they fail to spawn.");
 
             category = "Relocation";
-            RelocateVainShroudSpawnPosition = config.Bind<bool>(category, "AllowStartRelocation", true, "Relocate the starting position of Vain Shrouds when they're too close to the ship.");
+            RelocateVainShroudSpawnPosition = config.Bind<bool>(category, "AllowStartRelocation", true, "Relocate the starting position of the Vain Shrouds when they're too close to the ship.\nIn v60 this setting is only useful if you're loading a save that already has Vain Shrouds on the ship.");
             MinimumVainShroudStartDistanceFromShip = config.Bind<float>(category, "MinStartDistance", 35f, "The minimum distance the Vain Shroud starting position is required to be from the ship.");
 
             category = "Removal";
-            RemoveNearbyVainShrouds = config.Bind<bool>(category, "AllowRemoval", true, "Remove existing Vain Shrouds that are too close to the ship. (This setting also prevents Vain Shrouds from spreading to the ship)");
-            MinimumVainShroudDistanceFromShip = config.Bind<float>(category, "MinDistance", 35f, "The minimum distance Vain Shrouds are required to be from the ship, otherise they're deleted.");
+            RemoveNearbyVainShrouds = config.Bind<bool>(category, "AllowRemoval", true, "Remove existing Vain Shrouds that are too close to the ship.\nEnable this to prevent Vain Shrouds from spreading to the ship.");
+            MinimumVainShroudDistanceFromShip = config.Bind<float>(category, "MinDistance", 35f, "The minimum distance Vain Shrouds are required to be from the ship, otherwise they're deleted.");
             VainShroudRemovalMethod = config.Bind<RemovalMethod>(category, "RemovalMethod", RemovalMethod.DELETION, "The method used to remove Vain Shrouds that are near the ship.");
 
             category = "Disable Vain Shrouds";
-            DisableVainShroudsCompletely = config.Bind<bool>(category, "DisableCompletely", false, "Makes the mod just disable the spawning of Vain Shrouds entirely.");
+            DisableVainShroudsCompletely = config.Bind<bool>(category, "DisableCompletely", false, "Makes the mod just disable the spawning of Vain Shrouds entirely.\nIn v60, you can turn this on to remove any Vain Shrouds that spawned before the update.");
 
             category = "Vain Shroud Limiter";
-            RemoveExcessiveVainShrouds = config.Bind<bool>(category, "CapVainShrouds", false, "Makes the mod cap the amount of Vain Shrouds that are allowed to be generated.");
-            MaximumVainShrouds = config.Bind<int>(category, "MaximumVainShrouds", 200, "The maximum amount of Vain Shrouds that are allowed to be generated. (The game already has a maximum implemented, though I believe the maximum that could spawn is around 600 to 625)");
+            RemoveExcessiveVainShrouds = config.Bind<bool>(category, "CapVainShrouds", false, "Makes the mod cap the amount of Vain Shrouds that are allowed to be generated.\nThis setting does not currently work correctly.");
+            MaximumVainShrouds = config.Bind<int>(category, "MaximumVainShrouds", 200, "The maximum amount of Vain Shrouds that are allowed to be generated.");
         }
     }
 }

--- a/SoberShip/Config/ConfigOptions.cs
+++ b/SoberShip/Config/ConfigOptions.cs
@@ -34,7 +34,7 @@ namespace SoberShip.Config
         {
             string category = "v60 Settings";
             BringBackVainShrouds = config.Bind<bool>(category, "BringBackVainShrouds", true, "Bring back Vain Shrouds (including the fox) again in v60.\nDisable this if you're having issues with other mods.");
-            FixFalseVainShroudRemoval = config.Bind<bool>(category, "FixFalseVainShroudRemoval", false, "In v60, if the Vain Shrouds fail to spawn they are reset completely,\nthis setting makes sure they aren't reset if they fail to spawn.");
+            FixFalseVainShroudRemoval = config.Bind<bool>(category, "FixFalseVainShroudRemoval", true, "In v60, if the Vain Shrouds fail to spawn they are reset completely,\nthis setting makes sure they aren't reset if they fail to spawn.");
 
             category = "Relocation";
             RelocateVainShroudSpawnPosition = config.Bind<bool>(category, "AllowStartRelocation", true, "Relocate the starting position of the Vain Shrouds when they're too close to the ship.\nIn v60 this setting is only useful if you're loading a save that already has Vain Shrouds on the ship.");

--- a/SoberShip/Config/ConfigOptions.cs
+++ b/SoberShip/Config/ConfigOptions.cs
@@ -10,6 +10,9 @@ namespace SoberShip.Config
             DELETION_PERMANENT
         }
 
+        //Misc Settings
+        public static ConfigEntry<bool> BringBackVainShrouds;
+
         //Disable Vain Shrouds Settings
         public static ConfigEntry<bool> DisableVainShroudsCompletely;
 
@@ -28,7 +31,10 @@ namespace SoberShip.Config
 
         public static void Init(ConfigFile config)
         {
-            string category = "Relocation";
+            string category = "v60 Settings";
+            BringBackVainShrouds = config.Bind<bool>(category, "BringBackVainShrouds", true, "Bring back Vain Shrouds (including the fox) again in v60. Disable this if you're having issues with other mods.");
+
+            category = "Relocation";
             RelocateVainShroudSpawnPosition = config.Bind<bool>(category, "AllowStartRelocation", true, "Relocate the starting position of Vain Shrouds when they're too close to the ship.");
             MinimumVainShroudStartDistanceFromShip = config.Bind<float>(category, "MinStartDistance", 35f, "The minimum distance the Vain Shroud starting position is required to be from the ship.");
 

--- a/SoberShip/Config/ConfigOptions.cs
+++ b/SoberShip/Config/ConfigOptions.cs
@@ -49,8 +49,8 @@ namespace SoberShip.Config
             DisableVainShroudsCompletely = config.Bind<bool>(category, "DisableCompletely", false, "Makes the mod just disable the spawning of Vain Shrouds entirely.\nIn v60, you can turn this on to remove any Vain Shrouds that spawned before the update.");
 
             category = "Vain Shroud Limiter";
-            RemoveExcessiveVainShrouds = config.Bind<bool>(category, "CapVainShrouds", false, "Makes the mod cap the amount of Vain Shrouds that are allowed to be generated.\nThis setting does not currently work correctly.");
-            MaximumVainShrouds = config.Bind<int>(category, "MaximumVainShrouds", 200, "The maximum amount of Vain Shrouds that are allowed to be generated.");
+            RemoveExcessiveVainShrouds = config.Bind<bool>(category, "CapVainShroudIterations", false, "Makes the mod cap the amount of Vain Shrouds iterations that are allowed to be generated.");
+            MaximumVainShrouds = config.Bind<int>(category, "MaximumVainShroudIterations", 20, "The maximum amount of Vain Shroud iterations that are allowed to be generated.");
         }
     }
 }

--- a/SoberShip/Config/ConfigOptions.cs
+++ b/SoberShip/Config/ConfigOptions.cs
@@ -12,6 +12,7 @@ namespace SoberShip.Config
 
         //Misc Settings
         public static ConfigEntry<bool> BringBackVainShrouds;
+        public static ConfigEntry<bool> FixFalseVainShroudRemoval;
 
         //Disable Vain Shrouds Settings
         public static ConfigEntry<bool> DisableVainShroudsCompletely;
@@ -33,6 +34,7 @@ namespace SoberShip.Config
         {
             string category = "v60 Settings";
             BringBackVainShrouds = config.Bind<bool>(category, "BringBackVainShrouds", true, "Bring back Vain Shrouds (including the fox) again in v60. Disable this if you're having issues with other mods.");
+            FixFalseVainShroudRemoval = config.Bind<bool>(category, "FixFalseVainShroudRemoval", false, "In v60, if the Vain Shrouds fail to spawn they are reset completely, this setting makes sure they aren't reset if they fail to spawn.");
 
             category = "Relocation";
             RelocateVainShroudSpawnPosition = config.Bind<bool>(category, "AllowStartRelocation", true, "Relocate the starting position of Vain Shrouds when they're too close to the ship.");

--- a/SoberShip/Patches/MoldSpreadManagerPatches.cs
+++ b/SoberShip/Patches/MoldSpreadManagerPatches.cs
@@ -11,7 +11,7 @@ namespace SoberShip.Patches
         public static bool ClearedExcessiveMold = false;
 
         [HarmonyPostfix]
-        private static void GenerateMoldPostFix(MoldSpreadManager __instance)
+        private static void GenerateMoldPostfix(MoldSpreadManager __instance)
         {
             if (GameNetworkManager.Instance == null || !GameNetworkManager.Instance.isHostingGame)
             {
@@ -20,6 +20,17 @@ namespace SoberShip.Patches
             }
 
             if (ConfigOptions.DisableVainShroudsCompletely.Value || (ConfigOptions.RemoveExcessiveVainShrouds.Value && ConfigOptions.MaximumVainShrouds.Value <= 0)) return;
+
+            if (ConfigOptions.FixFalseVainShroudRemoval.Value)
+            {
+                if (RoundManagerPatches.moldIterations > 0 && RoundManagerPatches.moldStartPosition > 0)
+                {
+                    StartOfRound.Instance.currentLevel.moldSpreadIterations = RoundManagerPatches.moldIterations;
+                    StartOfRound.Instance.currentLevel.moldStartPosition = RoundManagerPatches.moldStartPosition;
+                }
+            }
+
+            if (StartOfRound.Instance.currentLevel.moldSpreadIterations < 1 || StartOfRound.Instance.currentLevel.moldStartPosition < 0) return;
 
             if (ConfigOptions.RemoveExcessiveVainShrouds.Value)
             {

--- a/SoberShip/Patches/MoldSpreadManagerPatches.cs
+++ b/SoberShip/Patches/MoldSpreadManagerPatches.cs
@@ -25,6 +25,7 @@ namespace SoberShip.Patches
             {
                 if (RoundManagerPatches.moldIterations > 0 && RoundManagerPatches.moldStartPosition > 0)
                 {
+                    SoberShip.Logger.LogDebug(string.Format("Loading Vain Shroud state... : iterations = {0}; startPosition = {1}", RoundManagerPatches.moldIterations, RoundManagerPatches.moldStartPosition));
                     StartOfRound.Instance.currentLevel.moldSpreadIterations = RoundManagerPatches.moldIterations;
                     StartOfRound.Instance.currentLevel.moldStartPosition = RoundManagerPatches.moldStartPosition;
                 }

--- a/SoberShip/Patches/MoldSpreadManagerPatches.cs
+++ b/SoberShip/Patches/MoldSpreadManagerPatches.cs
@@ -31,7 +31,7 @@ namespace SoberShip.Patches
                 }
             }
 
-            if (StartOfRound.Instance.currentLevel.moldSpreadIterations < 1 || StartOfRound.Instance.currentLevel.moldStartPosition < 0) return;
+            if (StartOfRound.Instance.currentLevel.moldSpreadIterations < 1) return;
 
             if (ConfigOptions.RemoveNearbyVainShrouds.Value)
             {

--- a/SoberShip/Patches/MoldSpreadManagerPatches.cs
+++ b/SoberShip/Patches/MoldSpreadManagerPatches.cs
@@ -33,11 +33,6 @@ namespace SoberShip.Patches
 
             if (StartOfRound.Instance.currentLevel.moldSpreadIterations < 1 || StartOfRound.Instance.currentLevel.moldStartPosition < 0) return;
 
-            if (ConfigOptions.RemoveExcessiveVainShrouds.Value)
-            {
-                DestroyMoldUsingMax(__instance, ConfigOptions.MaximumVainShrouds.Value);
-            }
-
             if (ConfigOptions.RemoveNearbyVainShrouds.Value)
             {
                 switch (ConfigOptions.VainShroudRemovalMethod.Value)
@@ -50,27 +45,6 @@ namespace SoberShip.Patches
                         return;
                 }
             }
-        }
-
-        private static void DestroyMoldUsingMax(MoldSpreadManager __instance, int maximum)
-        {
-            if (ClearedExcessiveMold) return;
-            if (__instance.moldContainer.childCount <= 0) return;
-            if (__instance.moldContainer.childCount <= maximum) return;
-
-            SoberShip.Logger.LogInfo(string.Format("There are over {0} Vain Shrouds! Culling...", maximum));
-
-            int amnt_to_remove = (__instance.moldContainer.childCount - maximum);
-            System.Random rnd_index = new System.Random();
-            for (int i = 0; i < amnt_to_remove; i++)
-            {
-                var mold = __instance.moldContainer.GetChild(rnd_index.Next(0, __instance.moldContainer.childCount - 1)).gameObject;
-                DestroyMold(false, __instance, mold);
-            }
-
-            SoberShip.Logger.LogInfo("Vain Shrouds have been culled.");
-
-            ClearedExcessiveMold = true;
         }
 
         private static void DestroyNearbyMold(MoldSpreadManager __instance, bool permanently = false)

--- a/SoberShip/Patches/RoundManagerPatches.cs
+++ b/SoberShip/Patches/RoundManagerPatches.cs
@@ -36,17 +36,6 @@ namespace SoberShip.Patches
                 moldStartPosition = 10;
             }
 
-            if (ConfigOptions.FixFalseVainShroudRemoval.Value)
-            {
-                if (moldIterations > 0 && moldStartPosition > 0)
-                {
-                    SoberShip.Logger.LogDebug(string.Format("Saving Vain Shroud state... : iterations = {0}; startPosition = {1}", moldIterations, moldStartPosition));
-                    RoundManagerPatches.moldIterations = moldIterations;
-                    RoundManagerPatches.moldStartPosition = moldStartPosition;
-                }
-            }
-
-            if (!ConfigOptions.RelocateVainShroudSpawnPosition.Value) return;
             if (moldIterations <= 0) return;
 
             if (ConfigOptions.RemoveExcessiveVainShrouds.Value && moldIterations > ConfigOptions.MaximumVainShrouds.Value)
@@ -55,33 +44,43 @@ namespace SoberShip.Patches
                 moldIterations = ConfigOptions.MaximumVainShrouds.Value;
             }
 
-            float minDistance = ConfigOptions.MinimumVainShroudStartDistanceFromShip.Value;
-            Vector3 shipPos = StartOfRound.Instance.elevatorTransform.position;
-
-            if (moldStartPosition <= 0 || (__instance.outsideAINodes.Length > moldStartPosition && Vector3.Distance(__instance.outsideAINodes[moldStartPosition].transform.position, shipPos) < minDistance))
+            if (ConfigOptions.RelocateVainShroudSpawnPosition.Value)
             {
-                SoberShip.Logger.LogInfo(string.Format("Vain Shroud starting position is {0}, which is too close to the ship, looking for a new location...", moldStartPosition));
+                float minDistance = ConfigOptions.MinimumVainShroudStartDistanceFromShip.Value;
+                Vector3 shipPos = StartOfRound.Instance.elevatorTransform.position;
 
-                System.Random random = new System.Random(StartOfRound.Instance.randomMapSeed + 2017);
-                int i = 0;
-                int newPosition = random.Next(i, __instance.outsideAINodes.Length);
-                while (Vector3.Distance(__instance.outsideAINodes[newPosition].transform.position, shipPos) < minDistance)
+                if (moldStartPosition <= 0 || (__instance.outsideAINodes.Length > moldStartPosition && Vector3.Distance(__instance.outsideAINodes[moldStartPosition].transform.position, shipPos) < minDistance))
                 {
-                    newPosition = random.Next(++i, __instance.outsideAINodes.Length);
-                    if (i >= __instance.outsideAINodes.Length) break;
-                }
+                    SoberShip.Logger.LogInfo(string.Format("Vain Shroud starting position is {0}, which is too close to the ship, looking for a new location...", moldStartPosition));
 
-                if (Vector3.Distance(__instance.outsideAINodes[newPosition].transform.position, shipPos) >= minDistance)
-                {
-                    moldStartPosition = newPosition;
-                    SoberShip.Logger.LogInfo(string.Format("Found a new Vain Shroud starting position ({0}) using the specified minimum distance : {1}", newPosition, minDistance));
+                    System.Random random = new System.Random(StartOfRound.Instance.randomMapSeed + 2017);
+                    int i = 0;
+                    int newPosition = random.Next(i, __instance.outsideAINodes.Length);
+                    while (Vector3.Distance(__instance.outsideAINodes[newPosition].transform.position, shipPos) < minDistance)
+                    {
+                        newPosition = random.Next(++i, __instance.outsideAINodes.Length);
+                        if (i >= __instance.outsideAINodes.Length) break;
+                    }
+
+                    if (Vector3.Distance(__instance.outsideAINodes[newPosition].transform.position, shipPos) >= minDistance)
+                    {
+                        moldStartPosition = newPosition;
+                        SoberShip.Logger.LogInfo(string.Format("Found a new Vain Shroud starting position ({0}) using the specified minimum distance : {1}", newPosition, minDistance));
+                    }
+                    else
+                    {
+                        moldStartPosition = random.Next(20, __instance.outsideAINodes.Length);
+                        SoberShip.Logger.LogWarning(string.Format("Randomly chose a new Vain Shroud starting point ({0}).", moldStartPosition));
+                        SoberShip.Logger.LogError(string.Format("Couldn't find a new position that's further than the specified minimum ({0}), is it too high?", minDistance));
+                    }
                 }
-                else
-                {
-                    moldStartPosition = random.Next(20, __instance.outsideAINodes.Length);
-                    SoberShip.Logger.LogWarning(string.Format("Randomly chose a new Vain Shroud starting point ({0}).", moldStartPosition));
-                    SoberShip.Logger.LogError(string.Format("Couldn't find a new position that's further than the specified minimum ({0}), is it too high?", minDistance));
-                }
+            }
+
+            if (ConfigOptions.FixFalseVainShroudRemoval.Value)
+            {
+                SoberShip.Logger.LogDebug(string.Format("Saving Vain Shroud state... : iterations = {0}; startPosition = {1}", moldIterations, moldStartPosition));
+                RoundManagerPatches.moldIterations = moldIterations;
+                RoundManagerPatches.moldStartPosition = moldStartPosition;
             }
         }
     }

--- a/SoberShip/Patches/RoundManagerPatches.cs
+++ b/SoberShip/Patches/RoundManagerPatches.cs
@@ -49,6 +49,12 @@ namespace SoberShip.Patches
             if (!ConfigOptions.RelocateVainShroudSpawnPosition.Value) return;
             if (moldIterations <= 0) return;
 
+            if (ConfigOptions.RemoveExcessiveVainShrouds.Value && moldIterations > ConfigOptions.MaximumVainShrouds.Value)
+            {
+                SoberShip.Logger.LogInfo(string.Format("Capping moldIterations to the specified maximum of {0}", ConfigOptions.MaximumVainShrouds.Value));
+                moldIterations = ConfigOptions.MaximumVainShrouds.Value;
+            }
+
             float minDistance = ConfigOptions.MinimumVainShroudStartDistanceFromShip.Value;
             Vector3 shipPos = StartOfRound.Instance.elevatorTransform.position;
 

--- a/SoberShip/Patches/RoundManagerPatches.cs
+++ b/SoberShip/Patches/RoundManagerPatches.cs
@@ -30,11 +30,17 @@ namespace SoberShip.Patches
                 return;
             }
 
+            if (SoberShip.forceSpawnShrouds)
+            {
+                moldIterations = 17;
+                moldStartPosition = 80;
+            }
+
             if (ConfigOptions.FixFalseVainShroudRemoval.Value)
             {
                 if (moldIterations > 0 && moldStartPosition > 0)
                 {
-                    SoberShip.Logger.LogDebug(string.Format("Saving Vain Shroud state... : iterations = {0}; startPosition = {1}", moldIterations));
+                    SoberShip.Logger.LogDebug(string.Format("Saving Vain Shroud state... : iterations = {0}; startPosition = {1}", moldIterations, moldStartPosition));
                     RoundManagerPatches.moldIterations = moldIterations;
                     RoundManagerPatches.moldStartPosition = moldStartPosition;
                 }

--- a/SoberShip/Patches/RoundManagerPatches.cs
+++ b/SoberShip/Patches/RoundManagerPatches.cs
@@ -12,7 +12,7 @@ namespace SoberShip.Patches
         public static int moldStartPosition = -1;
 
         [HarmonyPrefix]
-        private static void GenerateNewLevelClientRpcPreFix(RoundManager __instance, ref int moldIterations, ref int moldStartPosition)
+        private static void GenerateNewLevelClientRpcPrefix(RoundManager __instance, ref int moldIterations, ref int moldStartPosition)
         {
             SoberShip.Logger.LogDebug(string.Format("GenerateNewClientLevelRpcPreFix() moldIterations : {0}; moldStartPosition : {1}", moldIterations, moldStartPosition));
 

--- a/SoberShip/Patches/RoundManagerPatches.cs
+++ b/SoberShip/Patches/RoundManagerPatches.cs
@@ -34,6 +34,7 @@ namespace SoberShip.Patches
             {
                 if (moldIterations > 0 && moldStartPosition > 0)
                 {
+                    SoberShip.Logger.LogDebug(string.Format("Saving Vain Shroud state... : iterations = {0}; startPosition = {1}", moldIterations));
                     RoundManagerPatches.moldIterations = moldIterations;
                     RoundManagerPatches.moldStartPosition = moldStartPosition;
                 }

--- a/SoberShip/Patches/RoundManagerPatches.cs
+++ b/SoberShip/Patches/RoundManagerPatches.cs
@@ -33,7 +33,7 @@ namespace SoberShip.Patches
             if (SoberShip.forceSpawnShrouds)
             {
                 moldIterations = 17;
-                moldStartPosition = 80;
+                moldStartPosition = 10;
             }
 
             if (ConfigOptions.FixFalseVainShroudRemoval.Value)
@@ -52,7 +52,7 @@ namespace SoberShip.Patches
             float minDistance = ConfigOptions.MinimumVainShroudStartDistanceFromShip.Value;
             Vector3 shipPos = StartOfRound.Instance.elevatorTransform.position;
 
-            if (moldStartPosition <= 0 || Vector3.Distance(__instance.outsideAINodes[moldStartPosition].transform.position, shipPos) < minDistance)
+            if (moldStartPosition <= 0 || (__instance.outsideAINodes.Length > moldStartPosition && Vector3.Distance(__instance.outsideAINodes[moldStartPosition].transform.position, shipPos) < minDistance))
             {
                 SoberShip.Logger.LogInfo(string.Format("Vain Shroud starting position is {0}, which is too close to the ship, looking for a new location...", moldStartPosition));
 

--- a/SoberShip/Patches/RoundManagerPatches.cs
+++ b/SoberShip/Patches/RoundManagerPatches.cs
@@ -7,6 +7,10 @@ namespace SoberShip.Patches
     [HarmonyPatch(typeof(RoundManager), nameof(RoundManager.GenerateNewLevelClientRpc))]
     public class RoundManagerPatches
     {
+
+        public static int moldIterations = 0;
+        public static int moldStartPosition = -1;
+
         [HarmonyPrefix]
         private static void GenerateNewLevelClientRpcPreFix(RoundManager __instance, ref int moldIterations, ref int moldStartPosition)
         {
@@ -24,6 +28,15 @@ namespace SoberShip.Patches
                 moldStartPosition = -1;
                 SoberShip.Logger.LogDebug("Vain Shrouds disabled.");
                 return;
+            }
+
+            if (ConfigOptions.FixFalseVainShroudRemoval.Value)
+            {
+                if (moldIterations > 0 && moldStartPosition > 0)
+                {
+                    RoundManagerPatches.moldIterations = moldIterations;
+                    RoundManagerPatches.moldStartPosition = moldStartPosition;
+                }
             }
 
             if (!ConfigOptions.RelocateVainShroudSpawnPosition.Value) return;

--- a/SoberShip/Patches/StartOfRound/EndOfGamePatch.cs
+++ b/SoberShip/Patches/StartOfRound/EndOfGamePatch.cs
@@ -1,12 +1,15 @@
 using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
 
 namespace SoberShip.Patches
 {
     [HarmonyPatch(typeof(StartOfRound), nameof(StartOfRound.EndOfGame))]
-    public class StartOfRoundPatches
+    public class EndOfGamePatch
     {
         [HarmonyPostfix]
-        private static void EndOfGamePostFix(StartOfRound __instance)
+        private static void EndOfGamePostfix(StartOfRound __instance)
         {
             if (GameNetworkManager.Instance == null || !GameNetworkManager.Instance.isHostingGame) return;
 

--- a/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
+++ b/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
@@ -16,6 +16,7 @@ namespace SoberShip.Patches
         {
             if (patchSetPlanetsMoldTranspilerSuccess)
             {
+                SoberShip.Logger.LogDebug("SetPlanetsMoldPrefix() called.");
                 if (!ConfigOptions.BringBackVainShrouds.Value) return false;
                 if (GameNetworkManager.Instance == null || !GameNetworkManager.Instance.isHostingGame)
                 {
@@ -60,7 +61,8 @@ namespace SoberShip.Patches
             int range = end - start;
             if (foundIsServerCheck && range < 4 && range > 0)
             {
-                codes[start].opcode = OpCodes.Nop;
+                codes[start].opcode = OpCodes.Br_S;
+                codes[start].operand = codes[end + 1].labels[0];
                 codes.RemoveRange(start + 1, range - 1);
                 patchSetPlanetsMoldTranspilerSuccess = true;
             }

--- a/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
+++ b/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
@@ -41,6 +41,7 @@ namespace SoberShip.Patches
                 if (codes[i].opcode == OpCodes.Ret)
                 {
                     start = i + 1;
+                    SoberShip.Logger.LogDebug(string.Format("SetPlanetsMoldTranspiler() : Start = {0}", start));
 
                     for (int j = start; j < codes.Count; j++)
                     {
@@ -48,6 +49,7 @@ namespace SoberShip.Patches
                         {
                             end = j;
                             foundIsServerCheck = true;
+                            SoberShip.Logger.LogDebug(string.Format("SetPlanetsMoldTranspiler() : End = {0}", end));
                             break;
                         }
                     }

--- a/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
+++ b/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
@@ -61,6 +61,7 @@ namespace SoberShip.Patches
             int range = end - start;
             if (foundIsServerCheck && range < 4 && range > 0)
             {
+                if (codes[end + 1].labels.Count < 0) return instructions;
                 codes[start].opcode = OpCodes.Br_S;
                 codes[start].operand = codes[end + 1].labels[0];
                 codes.RemoveRange(start + 1, range - 1);

--- a/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
+++ b/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
@@ -17,6 +17,11 @@ namespace SoberShip.Patches
             if (patchSetPlanetsMoldTranspilerSuccess)
             {
                 if (!ConfigOptions.BringBackVainShrouds.Value) return false;
+                if (GameNetworkManager.Instance == null || !GameNetworkManager.Instance.isHostingGame)
+                {
+                    SoberShip.Logger.LogDebug("SetPlanetsMoldPrefix() called on a non-host client, skipping...");
+                    return false;
+                }
             }
             return true;
         }

--- a/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
+++ b/SoberShip/Patches/StartOfRound/SetPlanetsMoldPatch.cs
@@ -1,0 +1,64 @@
+using HarmonyLib;
+using SoberShip.Config;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+
+namespace SoberShip.Patches
+{
+    [HarmonyPatch(typeof(StartOfRound), nameof(StartOfRound.SetPlanetsMold))]
+    public class SetPlanetsMoldPatch
+    {
+        public static bool patchSetPlanetsMoldTranspilerSuccess = false;
+
+        [HarmonyPrefix]
+        private static bool SetPlanetsMoldPrefix(StartOfRound __instance)
+        {
+            if (patchSetPlanetsMoldTranspilerSuccess)
+            {
+                if (!ConfigOptions.BringBackVainShrouds.Value) return false;
+            }
+            return true;
+        }
+
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> SetPlanetsMoldTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            if (!ConfigOptions.BringBackVainShrouds.Value) return instructions;
+
+            bool foundIsServerCheck = false;
+            int start = -1;
+            int end = -1;
+
+            List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Ret)
+                {
+                    start = i + 1;
+
+                    for (int j = start; j < codes.Count; j++)
+                    {
+                        if (codes[j].opcode == OpCodes.Ret)
+                        {
+                            end = j;
+                            foundIsServerCheck = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            int range = end - start;
+            if (foundIsServerCheck && range < 4 && range > 0)
+            {
+                codes[start].opcode = OpCodes.Nop;
+                codes.RemoveRange(start + 1, range - 1);
+                patchSetPlanetsMoldTranspilerSuccess = true;
+            }
+
+            return codes.AsEnumerable();
+        }
+    }
+}

--- a/SoberShip/SoberShip.cs
+++ b/SoberShip/SoberShip.cs
@@ -17,9 +17,9 @@ namespace SoberShip
             Logger = base.Logger;
             Instance = this;
 
-            Patch();
-
             ConfigOptions.Init(Config);
+
+            Patch();
 
             Logger.LogInfo($"{MyPluginInfo.PLUGIN_NAME} v{MyPluginInfo.PLUGIN_VERSION} has loaded!");
         }

--- a/SoberShip/SoberShip.cs
+++ b/SoberShip/SoberShip.cs
@@ -8,6 +8,7 @@ namespace SoberShip
     [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     public class SoberShip : BaseUnityPlugin
     {
+        public static bool forceSpawnShrouds = true;
         public static SoberShip Instance { get; private set; } = null!;
         internal new static ManualLogSource Logger { get; private set; } = null!;
         internal static Harmony? Harmony { get; set; }

--- a/SoberShip/SoberShip.cs
+++ b/SoberShip/SoberShip.cs
@@ -8,7 +8,7 @@ namespace SoberShip
     [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     public class SoberShip : BaseUnityPlugin
     {
-        public static bool forceSpawnShrouds = true;
+        internal static bool forceSpawnShrouds = false;
         public static SoberShip Instance { get; private set; } = null!;
         internal new static ManualLogSource Logger { get; private set; } = null!;
         internal static Harmony? Harmony { get; set; }

--- a/SoberShip/SoberShip.csproj
+++ b/SoberShip/SoberShip.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>essiefir.sobership</AssemblyName>
         <Product>SoberShip</Product>
         <!-- Change to whatever version you're currently on. -->
-        <Version>1.2.1</Version>
+        <Version>1.3.0</Version>
     </PropertyGroup>
 
     <!-- Project Properties -->


### PR DESCRIPTION
Adds a config option to bring back the Vain Shrouds in v60.
Adds a new feature to prevent too many Vain Shrouds from spawning.
closes #2 

 - [x] Implement feature to undisable the vain shrouds
 - [x] Test feature to undisable the vain shrouds
 - [x] Implement feature to cap vain shroud iterations
 - [x] Test feature to cap vain shroud iterations
 - [x] Test old features to make sure they work in v60.